### PR TITLE
Switched to dynamic rather than static location

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
 language: ruby
 bundler_args: --without copyright
 rvm:
-  - 1.9.3
   - 2.0.0
-  - 2.1.0
+  - 2.1.10
+  - 2.2.5
+  - 2.3.1
   - ruby-head
-  - jruby-19mode
-  - jruby-head
+  - jruby-1.7.25
+  - jruby-9.1.2.0
 matrix:
   allow_failures:
-    - rvm: jruby-head
     - rvm: ruby-head
+    - rvm: jruby-9.1.2.0

--- a/lib/commands/abstract_command.rb
+++ b/lib/commands/abstract_command.rb
@@ -40,7 +40,7 @@ class Gem::AbstractCommand < Gem::Command
     if URI.parse( "#{url}" ).host != nil
       config.url = url
 
-      say 'The Nexus URL has been stored in #{config}'
+      say "The Nexus URL has been stored in #{config}"
     else
       raise 'no URL given'
     end

--- a/lib/commands/abstract_command.rb
+++ b/lib/commands/abstract_command.rb
@@ -40,7 +40,7 @@ class Gem::AbstractCommand < Gem::Command
     if URI.parse( "#{url}" ).host != nil
       config.url = url
 
-      say 'The Nexus URL has been stored in ~/.gem/nexus'
+      say 'The Nexus URL has been stored in #{config}'
     else
       raise 'no URL given'
     end
@@ -77,9 +77,9 @@ class Gem::AbstractCommand < Gem::Command
     unless config.always_prompt?
       config.authorization = @authorization
       if @authorization
-        say "Your Nexus credentials has been stored in #{config}"
+        say "Your Nexus credentials have been stored in #{config}"
       else
-        say "Your Nexus credentials has been deleted from #{config}"
+        say "Your Nexus credentials have been deleted from #{config}"
       end
     end
   end

--- a/test/abstract_command_test.rb
+++ b/test/abstract_command_test.rb
@@ -218,7 +218,7 @@ class AbstractCommandTest < CommandTest
       should "say that we configured the url" do
         @command.configure_url
         assert_received(@command) { |command| command.say("Enter the URL of the rubygems repository on a Nexus server") }
-        assert_received(@command) { |command| command.say("The Nexus URL has been stored in pkg/configsign") }
+        assert_received(@command) { |command| command.say("The Nexus URL has been stored in pkg/configurl") }
         assert_equal( @command.config.url, "http://url" )
       end
     end

--- a/test/abstract_command_test.rb
+++ b/test/abstract_command_test.rb
@@ -218,7 +218,7 @@ class AbstractCommandTest < CommandTest
       should "say that we configured the url" do
         @command.configure_url
         assert_received(@command) { |command| command.say("Enter the URL of the rubygems repository on a Nexus server") }
-        assert_received(@command) { |command| command.say("The Nexus URL has been stored in ~/.gem/nexus") }
+        assert_received(@command) { |command| command.say("The Nexus URL has been stored in pkg/configsign") }
         assert_equal( @command.config.url, "http://url" )
       end
     end

--- a/test/abstract_command_test.rb
+++ b/test/abstract_command_test.rb
@@ -192,7 +192,7 @@ class AbstractCommandTest < CommandTest
       should "say that we signed in" do
         @command.sign_in
         assert_received(@command) { |command| command.say("Enter your Nexus credentials") }
-        assert_received(@command) { |command| command.say("Your Nexus credentials has been stored in pkg/configsign") }
+        assert_received(@command) { |command| command.say("Your Nexus credentials have been stored in pkg/configsign") }
         assert_equal( @command.config.authorization, 
                       "Basic dXNlcm5hbWU6cGFzc3dvcmQgMDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODk=" )
       end


### PR DESCRIPTION
Based on testing from a VM where it said it was at a location it wasn't.

Also corrected grammar tense.