### PR TITLE
Ignore SSL Certificate Errors

### DIFF
--- a/lib/commands/abstract_command.rb
+++ b/lib/commands/abstract_command.rb
@@ -23,6 +23,11 @@ class Gem::AbstractCommand < Gem::Command
                 "File location of nexus config to use.\n                                     default #{Nexus::Config.default_file}" ) do |value, options|
       options[ :nexus_config ] = File.expand_path( value )
     end
+
+    add_option( '--ignore-ssl-errors',
+                "No check certificate." ) do |value, options|
+      options[ :ssl_verify_mode ] = OpenSSL::SSL::VERIFY_NONE
+    end
   end
 
   def url
@@ -109,6 +114,8 @@ class Gem::AbstractCommand < Gem::Command
 
     if url.scheme == 'https'
       http.use_ssl = true
+      http.verify_mode =
+        options[ :ssl_verify_mode ] || config.ssl_verify_mode || OpenSSL::SSL::VERIFY_PAIR
     end
     
     #Because sometimes our gems are huge and our people are on vpns

--- a/lib/commands/abstract_command.rb
+++ b/lib/commands/abstract_command.rb
@@ -115,7 +115,7 @@ class Gem::AbstractCommand < Gem::Command
     if url.scheme == 'https'
       http.use_ssl = true
       http.verify_mode =
-        options[ :ssl_verify_mode ] || config.ssl_verify_mode || OpenSSL::SSL::VERIFY_PAIR
+        options[ :ssl_verify_mode ] || config.ssl_verify_mode || OpenSSL::SSL::VERIFY_PEER
     end
     
     #Because sometimes our gems are huge and our people are on vpns

--- a/lib/nexus/config.rb
+++ b/lib/nexus/config.rb
@@ -190,6 +190,10 @@ module Nexus
       @conf.store
     end
 
+    def ssl_verify_mode
+      @conf[ :ssl_verify_mode, @repo ]
+    end
+
     def to_s
       config.file
     end

--- a/test/abstract_command_test.rb
+++ b/test/abstract_command_test.rb
@@ -222,5 +222,27 @@ class AbstractCommandTest < CommandTest
         assert_equal( @command.config.url, "http://url" )
       end
     end
+
+    context "SSL verification" do
+      setup do
+        @url = "https://url"
+        @connection = Net::HTTP.new("host", 443)
+        stub(@connection).request
+        stub(Net::HTTP).new { @connection }
+        @command.config.url = @url
+      end
+
+      should "disable SSL verification" do
+        stub(@command.config).ssl_verify_mode { OpenSSL::SSL::VERIFY_NONE }
+        stub(Gem.configuration).verbose { 0 }
+        @command.make_request(:put, "gems/gem")
+        assert_equal( @connection.verify_mode, OpenSSL::SSL::VERIFY_NONE )
+      end
+
+      should "verify SSL" do
+        @command.make_request(:put, "gems/gem")
+        assert_equal( @connection.verify_mode, OpenSSL::SSL::VERIFY_PEER )
+      end
+    end
   end
 end


### PR DESCRIPTION
Gives the option to ignore invalid certificates (such as when a self-signed cert is used).